### PR TITLE
Private accounts and statuses only

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -187,6 +187,10 @@ class Account < ApplicationRecord
     Follow.where(target_account_id: id).count
   end
 
+  def locked?
+    true
+  end
+
   def to_webfinger_s
     "acct:#{local_username_and_domain}"
   end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -27,7 +27,7 @@
 #  header_file_size              :integer
 #  header_updated_at             :datetime
 #  avatar_remote_url             :string
-#  locked                        :boolean          default(FALSE), not null
+#  locked                        :boolean          default(TRUE), not null
 #  header_remote_url             :string           default(""), not null
 #  last_webfingered_at           :datetime
 #  inbox_url                     :string           default(""), not null
@@ -185,10 +185,6 @@ class Account < ApplicationRecord
 
   def local_followers_count
     Follow.where(target_account_id: id).count
-  end
-
-  def locked?
-    true
   end
 
   def to_webfinger_s

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -245,7 +245,7 @@ class User < ApplicationRecord
   end
 
   def setting_default_privacy
-    settings.default_privacy || (account.locked? ? 'private' : 'public')
+    'private'
   end
 
   def allows_digest_emails?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -245,7 +245,7 @@ class User < ApplicationRecord
   end
 
   def setting_default_privacy
-    'private'
+    settings.default_privacy || 'private'
   end
 
   def allows_digest_emails?

--- a/app/views/settings/profiles/show.html.haml
+++ b/app/views/settings/profiles/show.html.haml
@@ -24,7 +24,7 @@
   %hr.spacer/
 
   .fields-group
-    = f.input :locked, as: :boolean, wrapper: :with_label, hint: t('simple_form.hints.defaults.locked')
+    = f.input :locked, disabled: true, as: :boolean, wrapper: :with_label, hint: t('simple_form.hints.defaults.locked')
 
   .fields-group
     = f.input :bot, as: :boolean, wrapper: :with_label, hint: t('simple_form.hints.defaults.bot')

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -42,7 +42,7 @@ en:
         inbox_url: Copy the URL from the frontpage of the relay you want to use
         irreversible: Filtered posts will disappear irreversibly, even if filter is later removed
         locale: The language of the user interface, e-mails and push notifications
-        locked: Manually control who can follow you by approving follow requests
+        locked: Manually control who can follow you by approving follow requests. For your privacy, this is always enabled.
         password: Use at least 8 characters
         phrase: Will be matched regardless of casing in text or content warning of a post
         scopes: Which APIs the application will be allowed to access. If you select a top-level scope, you don't need to select individual ones.

--- a/db/migrate/20210518002014_default_account_locked_to_true.rb
+++ b/db/migrate/20210518002014_default_account_locked_to_true.rb
@@ -1,0 +1,5 @@
+class DefaultAccountLockedToTrue < ActiveRecord::Migration[6.1]
+  def change
+    change_column_default :accounts, :locked, from: false, to: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_05_174616) do
+ActiveRecord::Schema.define(version: 2021_05_18_002014) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -166,7 +166,7 @@ ActiveRecord::Schema.define(version: 2021_05_05_174616) do
     t.integer "header_file_size"
     t.datetime "header_updated_at"
     t.string "avatar_remote_url"
-    t.boolean "locked", default: false, null: false
+    t.boolean "locked", default: true, null: false
     t.string "header_remote_url", default: "", null: false
     t.datetime "last_webfingered_at"
     t.string "inbox_url", default: "", null: false
@@ -188,8 +188,8 @@ ActiveRecord::Schema.define(version: 2021_05_05_174616) do
     t.integer "avatar_storage_schema_version"
     t.integer "header_storage_schema_version"
     t.string "devices_url"
-    t.integer "suspension_origin"
     t.datetime "sensitized_at"
+    t.integer "suspension_origin"
     t.index "(((setweight(to_tsvector('simple'::regconfig, (display_name)::text), 'A'::\"char\") || setweight(to_tsvector('simple'::regconfig, (username)::text), 'B'::\"char\")) || setweight(to_tsvector('simple'::regconfig, (COALESCE(domain, ''::character varying))::text), 'C'::\"char\")))", name: "search_index", using: :gin
     t.index "lower((username)::text), COALESCE(lower((domain)::text), ''::text)", name: "index_accounts_on_username_and_domain_lower", unique: true
     t.index ["moved_to_account_id"], name: "index_accounts_on_moved_to_account_id"
@@ -482,12 +482,12 @@ ActiveRecord::Schema.define(version: 2021_05_05_174616) do
   end
 
   create_table "ip_blocks", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.datetime "expires_at"
     t.inet "ip", default: "0.0.0.0", null: false
     t.integer "severity", default: 0, null: false
+    t.datetime "expires_at"
     t.text "comment", default: "", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "list_accounts", force: :cascade do |t|
@@ -793,8 +793,8 @@ ActiveRecord::Schema.define(version: 2021_05_05_174616) do
   create_table "status_pins", force: :cascade do |t|
     t.bigint "account_id", null: false
     t.bigint "status_id", null: false
-    t.datetime "created_at", default: -> { "now()" }, null: false
-    t.datetime "updated_at", default: -> { "now()" }, null: false
+    t.datetime "created_at", default: -> { "CURRENT_TIMESTAMP" }, null: false
+    t.datetime "updated_at", default: -> { "CURRENT_TIMESTAMP" }, null: false
     t.index ["account_id", "status_id"], name: "index_status_pins_on_account_id_and_status_id", unique: true
   end
 

--- a/spec/controllers/api/v1/notifications_controller_spec.rb
+++ b/spec/controllers/api/v1/notifications_controller_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe Api::V1::NotificationsController, type: :controller do
 
   let(:user)  { Fabricate(:user, account: Fabricate(:account, username: 'alice', locked: false)) }
   let(:token) { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }
-  let(:other) { Fabricate(:user, account: Fabricate(:account, username: 'bob')) }
-  let(:third) { Fabricate(:user, account: Fabricate(:account, username: 'carol')) }
+  let(:other) { Fabricate(:user, account: Fabricate(:account, username: 'bob', locked: false)) }
+  let(:third) { Fabricate(:user, account: Fabricate(:account, username: 'carol', locked: false)) }
 
   before do
     allow(controller).to receive(:doorkeeper_token) { token }
@@ -51,7 +51,7 @@ RSpec.describe Api::V1::NotificationsController, type: :controller do
     let(:scopes) { 'read:notifications' }
 
     before do
-      first_status = PostStatusService.new.call(user.account, text: 'Test')
+      first_status = PostStatusService.new.call(user.account, text: 'Test', visibility: 'public')
       @reblog_of_first_status = ReblogService.new.call(other.account, first_status)
       mentioning_status = PostStatusService.new.call(other.account, text: 'Hello @alice')
       @mention_from_status = mentioning_status.mentions.first

--- a/spec/controllers/api/v1/notifications_controller_spec.rb
+++ b/spec/controllers/api/v1/notifications_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Api::V1::NotificationsController, type: :controller do
   render_views
 
-  let(:user)  { Fabricate(:user, account: Fabricate(:account, username: 'alice')) }
+  let(:user)  { Fabricate(:user, account: Fabricate(:account, username: 'alice', locked: false)) }
   let(:token) { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }
   let(:other) { Fabricate(:user, account: Fabricate(:account, username: 'bob')) }
   let(:third) { Fabricate(:user, account: Fabricate(:account, username: 'carol')) }

--- a/spec/controllers/api/v1/timelines/public_controller_spec.rb
+++ b/spec/controllers/api/v1/timelines/public_controller_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 describe Api::V1::Timelines::PublicController do
   render_views
 
-  let(:user) { Fabricate(:user, account: Fabricate(:account, username: 'alice')) }
+  let(:user) { Fabricate(:user, account: Fabricate(:account, username: 'alice', locked: false)) }
 
   before do
     allow(controller).to receive(:doorkeeper_token) { token }

--- a/spec/controllers/api/v1/timelines/public_controller_spec.rb
+++ b/spec/controllers/api/v1/timelines/public_controller_spec.rb
@@ -16,7 +16,7 @@ describe Api::V1::Timelines::PublicController do
 
     describe 'GET #show' do
       before do
-        PostStatusService.new.call(user.account, text: 'New status from user for federated public timeline.')
+        PostStatusService.new.call(user.account, text: 'New status from user for federated public timeline.', visibility: 'public')
       end
 
       it 'returns http success' do
@@ -29,7 +29,7 @@ describe Api::V1::Timelines::PublicController do
 
     describe 'GET #show with local only' do
       before do
-        PostStatusService.new.call(user.account, text: 'New status from user for local public timeline.')
+        PostStatusService.new.call(user.account, text: 'New status from user for local public timeline.', visibility: 'public')
       end
 
       it 'returns http success' do

--- a/spec/controllers/api/v1/timelines/tag_controller_spec.rb
+++ b/spec/controllers/api/v1/timelines/tag_controller_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 describe Api::V1::Timelines::TagController do
   render_views
 
-  let(:user) { Fabricate(:user, account: Fabricate(:account, username: 'alice')) }
+  let(:user) { Fabricate(:user, account: Fabricate(:account, username: 'alice', locked: false)) }
 
   before do
     allow(controller).to receive(:doorkeeper_token) { token }
@@ -16,7 +16,7 @@ describe Api::V1::Timelines::TagController do
 
     describe 'GET #show' do
       before do
-        PostStatusService.new.call(user.account, text: 'It is a #test')
+        PostStatusService.new.call(user.account, text: 'It is a #test', visibility: 'public')
       end
 
       it 'returns http success' do

--- a/spec/controllers/authorize_interactions_controller_spec.rb
+++ b/spec/controllers/authorize_interactions_controller_spec.rb
@@ -94,7 +94,7 @@ describe AuthorizeInteractionsController do
       end
 
       it 'follows account when found' do
-        target_account = Fabricate(:account)
+        target_account = Fabricate(:account, locked: false)
         service = double
 
         allow(ResolveAccountService).to receive(:new).and_return(service)

--- a/spec/lib/activitypub/activity/follow_spec.rb
+++ b/spec/lib/activitypub/activity/follow_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe ActivityPub::Activity::Follow do
-  let(:sender)    { Fabricate(:account) }
+  let(:sender)    { Fabricate(:account, locked: false) }
   let(:recipient) { Fabricate(:account) }
 
   let(:json) do

--- a/spec/lib/activitypub/activity/follow_spec.rb
+++ b/spec/lib/activitypub/activity/follow_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe ActivityPub::Activity::Follow do
   let(:sender)    { Fabricate(:account, locked: false) }
-  let(:recipient) { Fabricate(:account) }
+  let(:recipient) { Fabricate(:account, locked: false) }
 
   let(:json) do
     {

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -198,9 +198,9 @@ RSpec.describe User, type: :model do
       expect(user.setting_default_privacy).to eq 'private'
     end
 
-    it "returns 'public' if user has not configured default privacy setting and account is not locked" do
+    it "returns 'private' if user has not configured default privacy setting and account is not locked" do
       user = Fabricate(:user, account: Fabricate(:account, locked: false))
-      expect(user.setting_default_privacy).to eq 'public'
+      expect(user.setting_default_privacy).to eq 'private'
     end
   end
 

--- a/spec/services/follow_service_spec.rb
+++ b/spec/services/follow_service_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe FollowService, type: :service do
     end
 
     describe 'already followed account, turning reblogs off' do
-      let(:bob) { Fabricate(:user, email: 'bob@example.com', account: Fabricate(:account, username: 'bob'), locked: false).account }
+      let(:bob) { Fabricate(:user, email: 'bob@example.com', account: Fabricate(:account, username: 'bob', locked: false)).account }
 
       before do
         sender.follow!(bob, reblogs: true)
@@ -124,7 +124,7 @@ RSpec.describe FollowService, type: :service do
   end
 
   context 'remote ActivityPub account' do
-    let(:bob) { Fabricate(:user, account: Fabricate(:account, username: 'bob', domain: 'example.com', protocol: :activitypub, inbox_url: 'http://example.com/inbox')).account }
+    let(:bob) { Fabricate(:user, account: Fabricate(:account, username: 'bob', locked: false, domain: 'example.com', protocol: :activitypub, inbox_url: 'http://example.com/inbox')).account }
 
     before do
       stub_request(:post, "http://example.com/inbox").to_return(:status => 200, :body => "", :headers => {})

--- a/spec/services/follow_service_spec.rb
+++ b/spec/services/follow_service_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe FollowService, type: :service do
     end
 
     describe 'unlocked account, from silenced account' do
-      let(:bob) { Fabricate(:user, email: 'bob@example.com', account: Fabricate(:account, username: 'bob')).account }
+      let(:bob) { Fabricate(:user, email: 'bob@example.com', account: Fabricate(:account, username: 'bob', locked: false)).account }
 
       before do
         sender.touch(:silenced_at)
@@ -44,7 +44,7 @@ RSpec.describe FollowService, type: :service do
     end
 
     describe 'unlocked account, from a muted account' do
-      let(:bob) { Fabricate(:user, email: 'bob@example.com', account: Fabricate(:account, username: 'bob')).account }
+      let(:bob) { Fabricate(:user, email: 'bob@example.com', account: Fabricate(:account, username: 'bob', locked: false)).account }
 
       before do
         bob.mute!(sender)
@@ -58,7 +58,7 @@ RSpec.describe FollowService, type: :service do
     end
 
     describe 'unlocked account' do
-      let(:bob) { Fabricate(:user, email: 'bob@example.com', account: Fabricate(:account, username: 'bob')).account }
+      let(:bob) { Fabricate(:user, email: 'bob@example.com', account: Fabricate(:account, username: 'bob', locked: false)).account }
 
       before do
         subject.call(sender, bob)
@@ -71,7 +71,7 @@ RSpec.describe FollowService, type: :service do
     end
 
     describe 'unlocked account, no reblogs' do
-      let(:bob) { Fabricate(:user, email: 'bob@example.com', account: Fabricate(:account, username: 'bob')).account }
+      let(:bob) { Fabricate(:user, email: 'bob@example.com', account: Fabricate(:account, username: 'bob', locked: false)).account }
 
       before do
         subject.call(sender, bob, reblogs: false)
@@ -84,7 +84,7 @@ RSpec.describe FollowService, type: :service do
     end
 
     describe 'already followed account' do
-      let(:bob) { Fabricate(:user, email: 'bob@example.com', account: Fabricate(:account, username: 'bob')).account }
+      let(:bob) { Fabricate(:user, email: 'bob@example.com', account: Fabricate(:account, username: 'bob', locked: false)).account }
 
       before do
         sender.follow!(bob)
@@ -97,7 +97,7 @@ RSpec.describe FollowService, type: :service do
     end
 
     describe 'already followed account, turning reblogs off' do
-      let(:bob) { Fabricate(:user, email: 'bob@example.com', account: Fabricate(:account, username: 'bob')).account }
+      let(:bob) { Fabricate(:user, email: 'bob@example.com', account: Fabricate(:account, username: 'bob'), locked: false).account }
 
       before do
         sender.follow!(bob, reblogs: true)
@@ -110,7 +110,7 @@ RSpec.describe FollowService, type: :service do
     end
 
     describe 'already followed account, turning reblogs on' do
-      let(:bob) { Fabricate(:user, email: 'bob@example.com', account: Fabricate(:account, username: 'bob')).account }
+      let(:bob) { Fabricate(:user, email: 'bob@example.com', account: Fabricate(:account, username: 'bob', locked: false)).account }
 
       before do
         sender.follow!(bob, reblogs: false)

--- a/spec/views/statuses/show.html.haml_spec.rb
+++ b/spec/views/statuses/show.html.haml_spec.rb
@@ -16,7 +16,7 @@ describe 'statuses/show.html.haml', without_verify_partial_doubles: true do
   end
 
   it 'has valid author h-card and basic data for a detailed_status' do
-    alice  =  Fabricate(:account, username: 'alice', display_name: 'Alice')
+    alice  =  Fabricate(:account, username: 'alice', display_name: 'Alice', locked: false)
     bob    =  Fabricate(:account, username: 'bob', display_name: 'Bob')
     status =  Fabricate(:status, account: alice, text: 'Hello World')
     reply  =  Fabricate(:status, account: bob, thread: status, text: 'Hello Alice')

--- a/spec/workers/unfollow_follow_worker_spec.rb
+++ b/spec/workers/unfollow_follow_worker_spec.rb
@@ -3,9 +3,9 @@
 require 'rails_helper'
 
 describe UnfollowFollowWorker do
-  let(:local_follower)   { Fabricate(:user, email: 'bob@example.com', account: Fabricate(:account, username: 'bob')).account }
-  let(:source_account)   { Fabricate(:account) }
-  let(:target_account)   { Fabricate(:account) }
+  let(:local_follower)   { Fabricate(:user, email: 'bob@example.com', account: Fabricate(:account, username: 'bob', locked: false)).account }
+  let(:source_account)   { Fabricate(:account, locked: false) }
+  let(:target_account)   { Fabricate(:account, locked: false) }
   let(:show_reblogs)     { true }
 
   subject { described_class.new }


### PR DESCRIPTION
This PR changes the defaults with respect to privacy. All new accounts are locked by default, meaning they must approve followers and their posts are private. The option to unlock the account when editing the profile has been disabled with an expanded message explaining why:

<img width="638" alt="Screen Shot 2021-05-18 at 8 46 15 PM" src="https://user-images.githubusercontent.com/382669/118868830-85d88a00-b899-11eb-88ee-81e913dcab50.png">

At this time I have not completely removed the ability to make public posts or unlock accounts as this might introduce too many changes from the base project.