### PR TITLE
Allow push notifications via Expo

### DIFF
--- a/app/controllers/api/v1/push/subscriptions_controller.rb
+++ b/app/controllers/api/v1/push/subscriptions_controller.rb
@@ -13,6 +13,7 @@ class Api::V1::Push::SubscriptionsController < Api::BaseController
       endpoint: subscription_params[:endpoint],
       key_p256dh: subscription_params[:keys][:p256dh],
       key_auth: subscription_params[:keys][:auth],
+      expo: subscription_params[:expo],
       data: data_params,
       user_id: current_user.id,
       access_token_id: doorkeeper_token.id
@@ -46,7 +47,7 @@ class Api::V1::Push::SubscriptionsController < Api::BaseController
   end
 
   def subscription_params
-    params.require(:subscription).permit(:endpoint, keys: [:auth, :p256dh])
+    params.require(:subscription).permit(:endpoint, :expo, keys: [:auth, :p256dh])
   end
 
   def data_params

--- a/app/models/web/push_subscription.rb
+++ b/app/models/web/push_subscription.rb
@@ -5,13 +5,14 @@
 #
 #  id              :bigint(8)        not null, primary key
 #  endpoint        :string           not null
-#  key_p256dh      :string           not null
-#  key_auth        :string           not null
+#  key_p256dh      :string
+#  key_auth        :string
 #  data            :json
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
 #  access_token_id :bigint(8)
 #  user_id         :bigint(8)
+#  expo            :boolean          default(FALSE), not null
 #
 
 class Web::PushSubscription < ApplicationRecord
@@ -21,8 +22,8 @@ class Web::PushSubscription < ApplicationRecord
   has_one :session_activation, foreign_key: 'web_push_subscription_id', inverse_of: :web_push_subscription
 
   validates :endpoint, presence: true
-  validates :key_p256dh, presence: true
-  validates :key_auth, presence: true
+  validates :key_p256dh, presence: true, unless: expo?
+  validates :key_auth, presence: true, unless: expo?
 
   delegate :locale, to: :associated_user
 

--- a/app/models/web/push_subscription.rb
+++ b/app/models/web/push_subscription.rb
@@ -12,7 +12,7 @@
 #  updated_at      :datetime         not null
 #  access_token_id :bigint(8)
 #  user_id         :bigint(8)
-#  expo            :boolean          default(FALSE), not null
+#  expo            :string
 #
 
 class Web::PushSubscription < ApplicationRecord

--- a/app/models/web/push_subscription.rb
+++ b/app/models/web/push_subscription.rb
@@ -22,8 +22,8 @@ class Web::PushSubscription < ApplicationRecord
   has_one :session_activation, foreign_key: 'web_push_subscription_id', inverse_of: :web_push_subscription
 
   validates :endpoint, presence: true
-  validates :key_p256dh, presence: true, unless: expo?
-  validates :key_auth, presence: true, unless: expo?
+  validates :key_p256dh, presence: true, unless: :expo?
+  validates :key_auth, presence: true, unless: :expo?
 
   delegate :locale, to: :associated_user
 

--- a/app/workers/web/push_notification_worker.rb
+++ b/app/workers/web/push_notification_worker.rb
@@ -40,7 +40,7 @@ class Web::PushNotificationWorker
         # and must be removed
 
         if (400..499).cover?(response.code) && ![408, 429].include?(response.code)
-          @subscription.destroy!
+          raise Mastodon::UnexpectedResponseError, response
         elsif !(200...300).cover?(response.code)
           raise Mastodon::UnexpectedResponseError, response
         end
@@ -68,14 +68,7 @@ class Web::PushNotificationWorker
       )
 
       request.perform do |response|
-        # If the server responds with an error in the 4xx range
-        # that isn't about rate-limiting or timeouts, we can
-        # assume that the subscription is invalid or expired
-        # and must be removed
-
-        if (400..499).cover?(response.code) && ![408, 429].include?(response.code)
-          @subscription.destroy!
-        elsif !(200...300).cover?(response.code)
+        if !(200...300).cover?(response.code)
           raise Mastodon::UnexpectedResponseError, response
         end
       end

--- a/db/migrate/20210708211904_add_expo_to_web_push_subscriptions.rb
+++ b/db/migrate/20210708211904_add_expo_to_web_push_subscriptions.rb
@@ -1,0 +1,20 @@
+class AddExpoToWebPushSubscriptions < ActiveRecord::Migration[6.1]
+  def up
+    safety_assured do
+      change_table(:web_push_subscriptions) do |t|
+        t.column :expo, :boolean, default: false, null: false 
+        t.change :key_p256dh, :string, null: true
+        t.change :key_auth, :string, null: true
+      end
+    end
+  end
+  def down
+    safety_assured do
+      change_table(:web_push_subscriptions) do |t|
+        t.remove :expo
+        t.change :key_p256dh, :string, null: false
+        t.change :key_auth, :string, null: false
+      end
+    end
+  end
+end

--- a/db/migrate/20210708211904_add_expo_to_web_push_subscriptions.rb
+++ b/db/migrate/20210708211904_add_expo_to_web_push_subscriptions.rb
@@ -2,7 +2,7 @@ class AddExpoToWebPushSubscriptions < ActiveRecord::Migration[6.1]
   def up
     safety_assured do
       change_table(:web_push_subscriptions) do |t|
-        t.column :expo, :boolean, default: false, null: false 
+        t.column :expo, :string
         t.change :key_p256dh, :string, null: true
         t.change :key_auth, :string, null: true
       end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_09_202149) do
+ActiveRecord::Schema.define(version: 2021_07_08_211904) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -937,13 +937,14 @@ ActiveRecord::Schema.define(version: 2021_06_09_202149) do
 
   create_table "web_push_subscriptions", force: :cascade do |t|
     t.string "endpoint", null: false
-    t.string "key_p256dh", null: false
-    t.string "key_auth", null: false
+    t.string "key_p256dh"
+    t.string "key_auth"
     t.json "data"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "access_token_id"
     t.bigint "user_id"
+    t.boolean "expo", default: false, null: false
     t.index ["access_token_id"], name: "index_web_push_subscriptions_on_access_token_id"
     t.index ["user_id"], name: "index_web_push_subscriptions_on_user_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -944,7 +944,7 @@ ActiveRecord::Schema.define(version: 2021_07_08_211904) do
     t.datetime "updated_at", null: false
     t.bigint "access_token_id"
     t.bigint "user_id"
-    t.boolean "expo", default: false, null: false
+    t.string "expo"
     t.index ["access_token_id"], name: "index_web_push_subscriptions_on_access_token_id"
     t.index ["user_id"], name: "index_web_push_subscriptions_on_user_id"
   end

--- a/spec/controllers/api/v1/push/subscriptions_controller_spec.rb
+++ b/spec/controllers/api/v1/push/subscriptions_controller_spec.rb
@@ -20,6 +20,7 @@ describe Api::V1::Push::SubscriptionsController do
           p256dh: 'BEm_a0bdPDhf0SOsrnB2-ategf1hHoCnpXgQsFj5JCkcoMrMt2WHoPfEYOYPzOIs9mZE8ZUaD7VA5vouy0kEkr8=',
           auth: 'eH_C8rq2raXqlcBVDa1gLg==',
         },
+        expo: true
       }
     }.with_indifferent_access
   end
@@ -53,6 +54,7 @@ describe Api::V1::Push::SubscriptionsController do
       expect(push_subscription.endpoint).to eq(create_payload[:subscription][:endpoint])
       expect(push_subscription.key_p256dh).to eq(create_payload[:subscription][:keys][:p256dh])
       expect(push_subscription.key_auth).to eq(create_payload[:subscription][:keys][:auth])
+      expect(push_subscription.expo).to eq(create_payload[:subscription][:expo])
       expect(push_subscription.user_id).to eq user.id
       expect(push_subscription.access_token_id).to eq token.id
     end

--- a/spec/controllers/api/v1/push/subscriptions_controller_spec.rb
+++ b/spec/controllers/api/v1/push/subscriptions_controller_spec.rb
@@ -20,7 +20,7 @@ describe Api::V1::Push::SubscriptionsController do
           p256dh: 'BEm_a0bdPDhf0SOsrnB2-ategf1hHoCnpXgQsFj5JCkcoMrMt2WHoPfEYOYPzOIs9mZE8ZUaD7VA5vouy0kEkr8=',
           auth: 'eH_C8rq2raXqlcBVDa1gLg==',
         },
-        expo: true
+        expo: 'token1234'
       }
     }.with_indifferent_access
   end

--- a/spec/workers/web/push_notification_worker_spec.rb
+++ b/spec/workers/web/push_notification_worker_spec.rb
@@ -45,8 +45,9 @@ describe Web::PushNotificationWorker do
       }, body: "+\xB8\xDBT}\u0013\xB6\xDD.\xF9\xB0\xA7\xC8Ҁ\xFD\x99#\xF7\xAC\x83\xA4\xDB,\u001F\xB5\xB9w\x85>\xF7\xADr")).to have_been_made
     end
 
-    it 'calls the relevant service with the correct headers when it is an expo subscription' do
+    it 'calls the relevant service with the correct headers and body when it is an expo subscription' do
       allow_any_instance_of(subscription.class).to receive(:expo?).and_return(true)
+      allow_any_instance_of(subscription.class).to receive(:expo).and_return('ExpoToken1234')
       subject.perform(subscription.id, notification.id)
 
       expect(a_request(:post, endpoint).with(headers: {
@@ -56,7 +57,7 @@ describe Web::PushNotificationWorker do
         'Host' => 'exp.host',
         'Ttl' => '172800',
         'Urgency' => 'normal',
-      }, body: "+\xB8\xDBT}\u0013\xB6\xDD.\xF9\xB0\xA7\xC8Ҁ\xFD\x99#\xF7\xAC\x83\xA4\xDB,\u001F\xB5\xB9w\x85>\xF7\xADr")).to have_been_made
+      }, body: { to: 'ExpoToken1234', title: be_an_instance_of(String), body: be_an_instance_of(String), icon: be_an_instance_of(String)})).to have_been_made
     end
   end
 end

--- a/spec/workers/web/push_notification_worker_spec.rb
+++ b/spec/workers/web/push_notification_worker_spec.rb
@@ -29,11 +29,11 @@ describe Web::PushNotificationWorker do
       allow(JWT).to receive(:encode).and_return('jwt.encoded.payload')
 
       stub_request(:post, endpoint).to_return(status: 201, body: '')
-
-      subject.perform(subscription.id, notification.id)
     end
 
     it 'calls the relevant service with the correct headers' do
+      subject.perform(subscription.id, notification.id)
+
       expect(a_request(:post, endpoint).with(headers: {
         'Content-Encoding' => 'aesgcm',
         'Content-Type' => 'application/octet-stream',
@@ -42,6 +42,20 @@ describe Web::PushNotificationWorker do
         'Ttl' => '172800',
         'Urgency' => 'normal',
         'Authorization' => 'WebPush jwt.encoded.payload',
+      }, body: "+\xB8\xDBT}\u0013\xB6\xDD.\xF9\xB0\xA7\xC8Ҁ\xFD\x99#\xF7\xAC\x83\xA4\xDB,\u001F\xB5\xB9w\x85>\xF7\xADr")).to have_been_made
+    end
+
+    it 'calls the relevant service with the correct headers when it is an expo subscription' do
+      allow_any_instance_of(subscription.class).to receive(:expo?).and_return(true)
+      subject.perform(subscription.id, notification.id)
+
+      expect(a_request(:post, endpoint).with(headers: {
+        'Content-Type' => 'application/json',
+        'Accept' => 'application/json',
+        'Accept-Encoding' => 'gzip, deflate',
+        'Host' => 'exp.host',
+        'Ttl' => '172800',
+        'Urgency' => 'normal',
       }, body: "+\xB8\xDBT}\u0013\xB6\xDD.\xF9\xB0\xA7\xC8Ҁ\xFD\x99#\xF7\xAC\x83\xA4\xDB,\u001F\xB5\xB9w\x85>\xF7\xADr")).to have_been_made
     end
   end


### PR DESCRIPTION
From the [push documentation](https://docs.joinmastodon.org/methods/notifications/push/):

> Mastodon natively supports the Web Push API. You can utilize the same mechanisms for your native app. It requires running a proxy server that connects to Android’s and Apple’s proprietary notification gateways. 

For apps built with [Expo](https://expo.io), push notifications can be sent directly to the Expo push server instead of running the proxy server yourself.

This modifies the web push subscription and worker to add an expo option. A subscription with an expo token does not encrypt the notification, and so doesn't generate the keys for encryption. I did this because I had some trouble generating the kind of keys the server would be happy with. I tried using the `elliptic-expo` module with each of the secp256k1, p256, and curve25519 curves with no luck. There is no sensitive information in the payload since notifications are of the form 'XXXX followed you', so I'm just going to the skip the encryption for non-web-push notifications.