### PR TITLE
Filter replies from the home feed

### DIFF
--- a/app/lib/feed_manager.rb
+++ b/app/lib/feed_manager.rb
@@ -347,7 +347,7 @@ class FeedManager
   # @return [Boolean]
   def filter_from_home?(status, receiver_id, crutches)
     return false if receiver_id == status.account_id
-    return true  if status.reply? && (status.in_reply_to_id.nil? || status.in_reply_to_account_id.nil?)
+    return true  if status.reply?
     return true  if phrase_filtered?(status, receiver_id, :home)
 
     check_for_blocks = crutches[:active_mentions][status.id] || []
@@ -360,13 +360,7 @@ class FeedManager
 
     return true if check_for_blocks.any? { |target_account_id| crutches[:blocking][target_account_id] || crutches[:muting][target_account_id] }
 
-    if status.reply? && !status.in_reply_to_account_id.nil?                                                                      # Filter out if it's a reply
-      should_filter   = !crutches[:following][status.in_reply_to_account_id]                                                     # and I'm not following the person it's a reply to
-      should_filter &&= receiver_id != status.in_reply_to_account_id                                                             # and it's not a reply to me
-      should_filter &&= status.account_id != status.in_reply_to_account_id                                                       # and it's not a self-reply
-
-      return !!should_filter
-    elsif status.reblog?                                                                                                         # Filter out a reblog
+    if status.reblog?                                                                                                         # Filter out a reblog
       should_filter   = crutches[:hiding_reblogs][status.account_id]                                                             # if the reblogger's reblogs are suppressed
       should_filter ||= crutches[:blocked_by][status.reblog.account_id]                                                          # or if the author of the reblogged status is blocking me
       should_filter ||= crutches[:domain_blocking][status.reblog.account.domain]                                                 # or the author's domain is blocked

--- a/app/workers/web/push_notification_worker.rb
+++ b/app/workers/web/push_notification_worker.rb
@@ -70,6 +70,12 @@ class Web::PushNotificationWorker
       request.perform do |response|
         if !(200...300).cover?(response.code)
           raise Mastodon::UnexpectedResponseError, response
+        else
+          response = response.data && response.data.first
+          status = response && response["status"]
+          if (status && status == "error")
+            raise Mastodon::UnexpectedResponseError, response["details"]["error"] + response["message"]
+          end
         end
       end
     end

--- a/spec/lib/feed_manager_spec.rb
+++ b/spec/lib/feed_manager_spec.rb
@@ -70,26 +70,26 @@ RSpec.describe FeedManager do
         expect(FeedManager.instance.filter?(:home, reblog, bob)).to be true
       end
 
-      it 'returns false for reply by followee to another followee' do
+      it 'returns true for reply by followee to another followee' do
         status = Fabricate(:status, text: 'Hello world', account: jeff)
         reply  = Fabricate(:status, text: 'Nay', thread: status, account: alice)
         bob.follow!(alice)
         bob.follow!(jeff)
-        expect(FeedManager.instance.filter?(:home, reply, bob)).to be false
+        expect(FeedManager.instance.filter?(:home, reply, bob)).to be true
       end
 
-      it 'returns false for reply by followee to recipient' do
+      it 'returns true for reply by followee to recipient' do
         status = Fabricate(:status, text: 'Hello world', account: bob)
         reply  = Fabricate(:status, text: 'Nay', thread: status, account: alice)
         bob.follow!(alice)
-        expect(FeedManager.instance.filter?(:home, reply, bob)).to be false
+        expect(FeedManager.instance.filter?(:home, reply, bob)).to be true
       end
 
-      it 'returns false for reply by followee to self' do
+      it 'returns true for reply by followee to self' do
         status = Fabricate(:status, text: 'Hello world', account: alice)
         reply  = Fabricate(:status, text: 'Nay', thread: status, account: alice)
         bob.follow!(alice)
-        expect(FeedManager.instance.filter?(:home, reply, bob)).to be false
+        expect(FeedManager.instance.filter?(:home, reply, bob)).to be true
       end
 
       it 'returns true for reply by followee to non-followed account' do


### PR DESCRIPTION
This fork aims to display replies more like comments than top-level statuses, therefore it doesn't make sense to include replies in the home timeline.