### PR TITLE
Exclude own statuses from home feed

### DIFF
--- a/app/lib/feed_manager.rb
+++ b/app/lib/feed_manager.rb
@@ -232,10 +232,6 @@ class FeedManager
     aggregate    = account.user&.aggregates_reblogs?
     timeline_key = key(:home, account.id)
 
-    account.statuses.limit(limit).each do |status|
-      add_to_feed(:home, account.id, status, aggregate)
-    end
-
     account.following.includes(:account_stat).find_each do |target_account|
       if redis.zcard(timeline_key) >= limit
         oldest_home_score = redis.zrange(timeline_key, 0, 0, with_scores: true).first.last.to_i

--- a/app/lib/feed_manager.rb
+++ b/app/lib/feed_manager.rb
@@ -346,7 +346,7 @@ class FeedManager
   # @param [Hash] crutches
   # @return [Boolean]
   def filter_from_home?(status, receiver_id, crutches)
-    return false if receiver_id == status.account_id
+    return true if receiver_id == status.account_id
     return true  if status.reply?
     return true  if phrase_filtered?(status, receiver_id, :home)
 

--- a/spec/lib/feed_manager_spec.rb
+++ b/spec/lib/feed_manager_spec.rb
@@ -26,6 +26,11 @@ RSpec.describe FeedManager do
     let(:jeff)  { Fabricate(:account, username: 'jeff') }
 
     context 'for home feed' do
+      it 'returns true for own status' do
+        status = Fabricate(:status, text: 'Hello world', account: alice)
+        expect(FeedManager.instance.filter?(:home, status, alice)).to be true
+      end
+
       it 'returns false for followee\'s status' do
         status = Fabricate(:status, text: 'Hello world', account: alice)
         bob.follow!(alice)


### PR DESCRIPTION
This PR changes the home feed to a timeline of activity from only users an account follows. Since an account doesn't follow itself, it should not populate the home feed with its own statuses.