### PR TITLE
Don't push own status to the home feed on fan out

### DIFF
--- a/app/services/fan_out_on_write_service.rb
+++ b/app/services/fan_out_on_write_service.rb
@@ -6,8 +6,6 @@ class FanOutOnWriteService < BaseService
   def call(status)
     raise Mastodon::RaceConditionError if status.visibility.nil?
 
-    deliver_to_self(status) if status.account.local?
-
     if status.direct_visibility?
       deliver_to_mentioned_followers(status)
       deliver_to_own_conversation(status)

--- a/spec/controllers/concerns/user_tracking_concern_spec.rb
+++ b/spec/controllers/concerns/user_tracking_concern_spec.rb
@@ -79,7 +79,7 @@ describe ApplicationController, type: :controller do
         get :show
 
         expect_updated_sign_in_at(user)
-        expect(Redis.current.zcard(FeedManager.instance.key(:home, user.account_id))).to eq 3
+        expect(Redis.current.zcard(FeedManager.instance.key(:home, user.account_id))).to eq 2
         expect(Redis.current.get("account:#{user.account_id}:regeneration")).to be_nil
       end
     end

--- a/spec/services/fan_out_on_write_service_spec.rb
+++ b/spec/services/fan_out_on_write_service_spec.rb
@@ -18,8 +18,8 @@ RSpec.describe FanOutOnWriteService, type: :service do
     subject.call(status)
   end
 
-  it 'delivers status to home timeline' do
-    expect(HomeFeed.new(author).get(10).map(&:id)).to include status.id
+  it 'does not deliver own status to home timeline' do
+    expect(HomeFeed.new(author).get(10).map(&:id)).not_to include status.id
   end
 
   it 'delivers status to local followers' do

--- a/spec/services/precompute_feed_service_spec.rb
+++ b/spec/services/precompute_feed_service_spec.rb
@@ -9,7 +9,9 @@ RSpec.describe PrecomputeFeedService, type: :service do
     let(:account) { Fabricate(:account) }
     it 'fills a user timeline with statuses' do
       account = Fabricate(:account)
-      status = Fabricate(:status, account: account)
+      following = Fabricate(:account, username: 'bob')
+      account.follow!(following)
+      status = Fabricate(:status, account: following)
 
       subject.call(account)
 


### PR DESCRIPTION
Follow up to #4. This removes one more place that was pushing a user's own status to the home feed.