### PR TITLE
Remove public and unlisted option for posts

### DIFF
--- a/app/javascript/mastodon/features/compose/components/privacy_dropdown.js
+++ b/app/javascript/mastodon/features/compose/components/privacy_dropdown.js
@@ -234,8 +234,6 @@ class PrivacyDropdown extends React.PureComponent {
     const { intl: { formatMessage } } = this.props;
 
     this.options = [
-      { icon: 'globe', value: 'public', text: formatMessage(messages.public_short), meta: formatMessage(messages.public_long) },
-      { icon: 'unlock', value: 'unlisted', text: formatMessage(messages.unlisted_short), meta: formatMessage(messages.unlisted_long) },
       { icon: 'lock', value: 'private', text: formatMessage(messages.private_short), meta: formatMessage(messages.private_long) },
     ];
 


### PR DESCRIPTION
All accounts are set to locked by default and statuses default to private in this fork, but this goes further by removing the public and unlisted options in the UI when creating a new status.

Before, when you could still choose public and unlisted options:
<img width="298" alt="Screen Shot 2021-10-18 at 4 50 09 PM" src="https://user-images.githubusercontent.com/382669/137821531-ed950ab0-cbb9-4751-836e-91d86381db6c.png">

After:
<img width="270" alt="Screen Shot 2021-10-18 at 4 49 51 PM" src="https://user-images.githubusercontent.com/382669/137821536-63f2df8f-b451-4e25-952e-9dba36856509.png">
