### PR TITLE
Use pre-signed URLs for media storage when using S3

### DIFF
--- a/lib/paperclip/storage_extensions.rb
+++ b/lib/paperclip/storage_extensions.rb
@@ -30,7 +30,7 @@ module Paperclip
           s3_object(style_name).presigned_url(
             :get,
             base_options.merge(s3_url_options)
-          ).to_s&.gsub(s3_url, ENV['S3_ALIAS'])
+          ).to_s&.gsub(s3_url, ENV['S3_ALIAS_HOST'])
         else
           super
         end

--- a/lib/paperclip/storage_extensions.rb
+++ b/lib/paperclip/storage_extensions.rb
@@ -26,10 +26,11 @@ module Paperclip
         time = 3600
         if path(style_name)
           base_options = { expires_in: time }
+          s3_url = ENV['S3_BUCKET'] + '.s3.' ENV['S3_REGION'] + '.amazonaws.com'
           s3_object(style_name).presigned_url(
             :get,
             base_options.merge(s3_url_options)
-          ).to_s
+          ).to_s.gsub(s3_url, ENV['S3_ALIAS'])
         else
           super
         end

--- a/lib/paperclip/storage_extensions.rb
+++ b/lib/paperclip/storage_extensions.rb
@@ -26,7 +26,7 @@ module Paperclip
         time = 3600
         if path(style_name)
           base_options = { expires_in: time }
-          s3_url = ENV['S3_BUCKET'] + '.s3.' ENV['S3_REGION'] + '.amazonaws.com'
+          s3_url = ENV['S3_BUCKET'] + '.s3.' + ENV['S3_REGION'] + '.amazonaws.com'
           s3_object(style_name).presigned_url(
             :get,
             base_options.merge(s3_url_options)

--- a/lib/paperclip/storage_extensions.rb
+++ b/lib/paperclip/storage_extensions.rb
@@ -16,6 +16,26 @@ if ENV['S3_ENABLED'] == 'true' && ENV['S3_FORCE_SINGLE_REQUEST'] == 'true'
       end
     end
   end
-
   Paperclip::Storage::S3.prepend(Paperclip::Storage::S3Extensions)
 end
+
+module Paperclip
+  module Storage
+    module S3SignedExtensions
+      def url(style_name = default_style)
+        time = 3600
+        if path(style_name)
+          base_options = { expires_in: time }
+          s3_object(style_name).presigned_url(
+            :get,
+            base_options.merge(s3_url_options)
+          ).to_s
+        else
+          super
+        end
+      end
+    end
+  end
+end
+
+Paperclip::Storage::S3.prepend(Paperclip::Storage::S3SignedExtensions)

--- a/lib/paperclip/storage_extensions.rb
+++ b/lib/paperclip/storage_extensions.rb
@@ -30,7 +30,7 @@ module Paperclip
           s3_object(style_name).presigned_url(
             :get,
             base_options.merge(s3_url_options)
-          ).to_s.gsub(s3_url, ENV['S3_ALIAS'])
+          ).to_s&.gsub(s3_url, ENV['S3_ALIAS'])
         else
           super
         end


### PR DESCRIPTION
The default way mastodon uses S3 for object storage is insecure:

* It requires buckets to be open to public access
* Anyone with the URL of a file can access it

This PR overrides all urls to be expiring urls when using S3 to fix these issues.

I did this with a monkey patch of the `url` method instead of changing all uses of `url` to `expiring_url` to minimize conflicts with upstream. I also had to manually gsub the output to use the local S3 alias due to https://github.com/thoughtbot/paperclip/issues/2196.