### PR TITLE
Fix media proxy to work with signed urls

### DIFF
--- a/heroku/nginx.conf.erb
+++ b/heroku/nginx.conf.erb
@@ -151,7 +151,7 @@ http {
       proxy_hide_header x-amz-bucket-region;
       proxy_hide_header x-amzn-requestid;
       proxy_ignore_headers Set-Cookie;
-      proxy_pass $s3_backend$uri;
+      proxy_pass $s3_backend$uri$is_args$args;
       proxy_intercept_errors off;
 
       proxy_cache CACHE;


### PR DESCRIPTION
This is needed because `$uri` does not include query params. I tried using `$request_uri` instead as documentation suggests that includes query params, but it didn't work, so this will do.